### PR TITLE
SKIPONLYONE 파일이 삭제 안되는 문제 수정

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,5 +89,5 @@ if __name__ == "__main__":
             routine(locale_inp, locale_out)
         if("SKIPONLYONE" in os.listdir('./cmd/')):
             routine(locale_inp, locale_out)
-            os.system('rm SKIPONLYONE')
+            os.system('rm ./cmd/SKIPONLYONE')
 


### PR DESCRIPTION
SKIPONLYONE 파일이 삭제 안되는 문제

```
rm: cannot remove 'SKIPONLYONE': No such file or directory
```

변경된 경로가 반영되지 않았음
app.py 92번째 줄 수정
```
os.system('rm ./cmd/SKIPONLYONE'):
```